### PR TITLE
Refactor PrestoConnection newConnectionWithSessionProperties

### DIFF
--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
@@ -128,18 +128,24 @@ public class PrestoConnection
     public static PrestoConnection newConnectionWithSessionProperties(PrestoConnection connectionWithSessionProperties, Properties connectionProperties)
             throws SQLException
     {
-        if (connectionWithSessionProperties != null) {
-            Map<String, String> map = connectionWithSessionProperties.getSessionProperties();
-            if (map != null) {
-                PrestoDriverUri uri = new PrestoDriverUri(connectionWithSessionProperties.getMetaData().getURL(), connectionProperties);
-                PrestoConnection prestoConnection = new PrestoConnection(uri, connectionWithSessionProperties.queryExecutor);
+        requireNonNull(connectionWithSessionProperties, "connectionWithSessionProperties is null");
 
-                map.forEach(prestoConnection::setSessionProperty);
-                return prestoConnection;
-            }
-        }
+        URI connectionWithSessionPropertiesURI = connectionWithSessionProperties.getURI();
+        String prestoUrl = format("%s://%s:%s%s", connectionWithSessionPropertiesURI.getScheme(), connectionWithSessionPropertiesURI.getHost(), connectionWithSessionPropertiesURI.getPort(), connectionWithSessionPropertiesURI.getPath());
+        PrestoDriverUri uri = new PrestoDriverUri(prestoUrl, connectionProperties);
+        PrestoConnection prestoConnection = new PrestoConnection(uri, connectionWithSessionProperties.queryExecutor);
+        copySessionProperties(connectionWithSessionProperties, prestoConnection);
 
-        return connectionWithSessionProperties;
+        return prestoConnection;
+    }
+
+    public static void copySessionProperties(PrestoConnection src, PrestoConnection dst)
+    {
+        requireNonNull(src, "src is null");
+        requireNonNull(dst, "dst is null");
+
+        Map<String, String> map = src.getSessionProperties();
+        map.forEach(dst::setSessionProperty);
     }
 
     @Override


### PR DESCRIPTION
- Removing queryParams from prestoUrl during connection creation to prevent infinite query execution loops for cases where queryInterceptors property is part of the connection url query parameters

- Added copySessionProperties method as part of the refactoring process and exposed it publicly to enable the copy of session properties from one connection to another without exposing getSessionProperties method from PrestoConnection class

## Description
<!---Describe your changes in detail-->
I recently worked on #20418, which enables the creation of PrestoConnections reusing session properties. 
The current implementation creates a new connection using the prestoConnection getMetdata().getURL() as the connection URL. This works fine in all cases except when queryInterceptor property is part of the URL queryParameters. In such cases a query interceptor loop would be created as every query executed will have an interceptor property.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Refactor #20418 to take into account cases where queryInterceptor is passed as a queryParameter URL


## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
- Refactor newConnectionWithSessionProperties to internally changed the logic used to create the presto connection URL 
- Include a new public method to allow  the copy PrestoConnection session properties (used as part of the refactoring)

## Test Plan
<!---Please fill in how you tested your change-->
- Run new test in TestJdbcConnection
- mvn clean install -rf :presto-jdbc
- Integration test used by loading the new driver and checking that the new presto connection constructor successfully returns a new PrestoConnection with the session of passed connection to the new constructor.
- Tested with both URL with and without queryInterceptors as part of the query parameters.

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==
JDB changes
* Add static method ``copySessionProperties`` to PrestoConnection to enable the copy of presto connection session properties from one connection to another. (:pr:`20418`)

